### PR TITLE
Adding .blaze extension to compiler

### DIFF
--- a/packages/templating-compiler/compile-templates.js
+++ b/packages/templating-compiler/compile-templates.js
@@ -1,5 +1,5 @@
 Plugin.registerCompiler({
-  extensions: ['html'],
+  extensions: ['html', 'blaze'],
   archMatching: 'web',
   isTemplate: true
 }, () => new CachingHtmlCompiler(


### PR DESCRIPTION
As discussed in https://github.com/meteor/blaze/issues/97, I believe it would be nice if Blaze accept `.blaze` extensions to avoid conflicts in editor's syntax highlighters.